### PR TITLE
Reduce browsing waiting time

### DIFF
--- a/app/src/main/java/com/vincent/mfssurfing/Constants.kt
+++ b/app/src/main/java/com/vincent/mfssurfing/Constants.kt
@@ -32,9 +32,9 @@ class Constants {
         val JAVASCRIPT_NAME = "HTMLOUT"
         val JAVASCRIPT_SYNTAX = "javascript:HTMLOUT.processHTML(document.documentElement.outerHTML);"
 
-        val MINIMUM_MANDATORY_JUMP_TIME = 45
+        val MINIMUM_BROWSING_SKIP_TIME = 45
         val KEY_IS_HANDLING_CAPTCHA_ALLOWED = "isHandlingCaptchaAllowed"
-        val KEY_AD_BROWSING_SKIP_SECOND = "mandatoryJumpTime"
+        val KEY_AD_BROWSING_SKIP_SECOND = "adBrowsingSkipTime"
         val KEY_IGNORED_AD_NUMBERS = "ignoredAdNumbers"
 
     }

--- a/app/src/main/java/com/vincent/mfssurfing/SettingOptionAdapter.kt
+++ b/app/src/main/java/com/vincent/mfssurfing/SettingOptionAdapter.kt
@@ -132,7 +132,7 @@ class SettingOptionAdapter (
         imgAction.setOnClickListener {
             AlertDialog.Builder(context)
                 .setTitle(context.getString(R.string.title_ignore_ad))
-                .setMessage("${context.getString(R.string.recover_ad)}$adNumber${context.getString(R.string.will_be_browse)}")
+                .setMessage("${context.getString(R.string.recover_ad)}$adNumber${context.getString(R.string.will_be_browsed)}")
                 .setPositiveButton(context.getString(R.string.yes)
                 ) { dialog, which ->
                     PreferencesHelper(context).deleteIgnoredAdNumber(adNumber)

--- a/app/src/main/java/com/vincent/mfssurfing/ThreadHelper.kt
+++ b/app/src/main/java/com/vincent/mfssurfing/ThreadHelper.kt
@@ -37,23 +37,12 @@ class ThreadHelper {
         startThread(operator, 0)
     }
 
-    fun startThread(operator: Operator, delayTimeMill: Long) {
+    fun startThread(operator: Operator, delayTimeMill: Long): Thread {
         val thread = object : Thread() {
             override fun run() {
                 super.run()
-                handler.sendMessageDelayed(generateMessage(operator), delayTimeMill)
-            }
-        }
-        thread.start()
-    }
-
-    fun launchTimer(operator: Operator, sleepTimeMill: Long): Thread {
-        val thread = object : Thread() {
-            override fun run() {
-                super.run()
-
                 try {
-                    Thread.sleep(sleepTimeMill)
+                    Thread.sleep(delayTimeMill)
                     handler.sendMessage(generateMessage(operator))
                 } catch (e: InterruptedException) {
                 }
@@ -64,9 +53,9 @@ class ThreadHelper {
         return thread
     }
 
-    fun stopTimer(timerThread: Thread) {
-        if (!timerThread.isInterrupted) {
-            timerThread.interrupt()
+    fun stopThread(thread: Thread?) {
+        if (thread != null && thread.isAlive) {
+            thread.interrupt()
         }
     }
 

--- a/app/src/main/java/com/vincent/mfssurfing/ThreadHelper.kt
+++ b/app/src/main/java/com/vincent/mfssurfing/ThreadHelper.kt
@@ -1,0 +1,83 @@
+package com.vincent.mfssurfing
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.os.Handler
+import android.os.Message
+import android.webkit.WebView
+import android.widget.TextView
+
+class ThreadHelper {
+
+    val handler = @SuppressLint("HandlerLeak")
+    object : Handler() {
+        override fun handleMessage(msg: Message?) {
+            super.handleMessage(msg)
+
+            val operator = msg?.data?.get(Constants.MESSAGE_KEY_OPERATOR) as Operator
+            operator.execute()
+        }
+    }
+
+    fun browseUrl(webView: WebView, url: String) {
+        val operator = object : Operator {
+            override fun execute() {
+                webView.loadUrl(url)
+            }
+        }
+        startThread(operator, 0)
+    }
+
+    fun updateStatus(txtStatus: TextView, message: String) {
+        val operator = object : Operator {
+            override fun execute() {
+                txtStatus.text = message
+            }
+        }
+        startThread(operator, 0)
+    }
+
+    fun startThread(operator: Operator, delayTimeMill: Long) {
+        val thread = object : Thread() {
+            override fun run() {
+                super.run()
+                handler.sendMessageDelayed(generateMessage(operator), delayTimeMill)
+            }
+        }
+        thread.start()
+    }
+
+    fun launchTimer(operator: Operator, sleepTimeMill: Long): Thread {
+        val thread = object : Thread() {
+            override fun run() {
+                super.run()
+
+                try {
+                    Thread.sleep(sleepTimeMill)
+                    handler.sendMessage(generateMessage(operator))
+                } catch (e: InterruptedException) {
+                }
+            }
+        }
+        thread.start()
+
+        return thread
+    }
+
+    fun stopTimer(timerThread: Thread) {
+        if (!timerThread.isInterrupted) {
+            timerThread.interrupt()
+        }
+    }
+
+    private fun generateMessage(operator: Operator): Message {
+        val bundle = Bundle()
+        bundle.putSerializable(Constants.MESSAGE_KEY_OPERATOR, operator)
+
+        val message = Message()
+        message.data = bundle
+
+        return message
+    }
+
+}

--- a/app/src/main/res/layout/seekbar_browsing_skip_time.xml
+++ b/app/src/main/res/layout/seekbar_browsing_skip_time.xml
@@ -5,7 +5,7 @@
         android:layout_height="match_parent">
 
     <SeekBar
-            android:id="@+id/seekJumpTime"
+            android:id="@+id/seekSkipTime"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_alignParentTop="true"
@@ -13,13 +13,13 @@
             android:progress="3"/>
 
     <TextView
-            android:id="@+id/txtJumpTime"
+            android:id="@+id/txtSkipTime"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@id/seekJumpTime"
+            android:layout_below="@id/seekSkipTime"
             android:layout_centerHorizontal="true"
             android:layout_marginTop="5dp"
             android:textSize="15sp"
-            android:textColor="#000"/>
+            android:textColor="#000000"/>
 
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,9 +29,9 @@
     <string name="auto_handle">自動處理</string>
     <string name="escape_handle">不處理</string>
 
-    <string name="title_mandatory_jump">強制跳離廣告</string>
-    <string name="desc_mandatory_jump">若廣告載入太久，可設置經過一定時間後，強制離開當前廣告。</string>
-    <string name="label_jump_time">%d秒後跳離</string>
+    <string name="title_skip_time">強制跳離廣告</string>
+    <string name="desc_skip_time">若廣告載入太久，可設置經過一定時間後，強制離開當前廣告。</string>
+    <string name="label_skip_time">%d秒後跳離</string>
 
     <string name="title_ignore_ad">排除廣告名單</string>
     <string name="desc_ignore_ad">忽略不想瀏覽的廣告。例如會扣錢的廣告，或者少數會使衝浪程式受阻的廣告。</string>
@@ -40,7 +40,7 @@
     <string name="ignored">已排除</string>
     <string name="recovered">已恢復</string>
     <string name="recover_ad">即將恢復廣告</string>
-    <string name="will_be_browse">，以後將被瀏覽</string>
+    <string name="will_be_browsed">，以後將被瀏覽</string>
 
     <string name="yes">是</string>
     <string name="no">否</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,11 +16,11 @@
     <string name="ad_clear">已經瀏覽完所有廣告</string>
     <string name="no_ad_can_browse">已經沒有廣告可瀏覽</string>
     <string name="do_not_disturb_surfing">衝浪進行中，請勿切換網頁</string>
-    <string name="connection_failed">無法連線到網頁，請檢查網路連線</string>
+    <string name="going_to_skip_ad">載入時間過久，將自動跳離廣告</string>
 
-    <string name="try_captcha_number">嘗試圖形驗證碼</string>
     <string name="loading_ad_page">載入廣告</string>
     <string name="browsing_ad_page">瀏覽廣告</string>
+    <string name="try_captcha_number">，嘗試驗證碼</string>
     <string name="time">，時間</string>
     <string name="second">秒</string>
 


### PR DESCRIPTION
Launch a credit timer when start loading ad page. After time's up, there'll be a flag to represent that the user is credited and no need to wait for the duration time.